### PR TITLE
Copy-paste support

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 // Requirements
 const {app, BrowserWindow, ipcMain} = require('electron')
-const Menu							= require('electron').Menu
+const Menu                          = require('electron').Menu
 const autoUpdater                   = require('electron-updater').autoUpdater
 const ejse                          = require('ejs-electron')
 const fs                            = require('fs')

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 // Requirements
 const {app, BrowserWindow, ipcMain} = require('electron')
+const Menu							= require('electron').Menu
 const autoUpdater                   = require('electron-updater').autoUpdater
 const ejse                          = require('ejs-electron')
 const fs                            = require('fs')
@@ -123,6 +124,65 @@ function createWindow() {
     })
 }
 
+function createMenu() {
+	
+	// Extend default included application menu to continue support for quit keyboard shortcut
+	let applicationSubMenu = {
+		label: "Application",
+		submenu: [{
+			label: "About Application",
+			selector: "orderFrontStandardAboutPanel:"
+		}, {
+			type: "separator"
+		}, {
+			label: "Quit",
+			accelerator: "Command+Q",
+			click: () => {
+				app.quit()
+			}
+		}]
+	}
+	
+	// New edit menu adds support for text-editing keyboard shortcuts
+	let editSubMenu = {
+		label: "Edit",
+		submenu: [{
+			label: "Undo",
+			accelerator: "CmdOrCtrl+Z",
+			selector: "undo:"
+		}, {
+			label: "Redo",
+			accelerator: "Shift+CmdOrCtrl+Z",
+			selector: "redo:"
+		}, {
+			type: "separator"
+		}, {
+			label: "Cut",
+			accelerator: "CmdOrCtrl+X",
+			selector: "cut:"
+		}, {
+			label: "Copy",
+			accelerator: "CmdOrCtrl+C",
+			selector: "copy:"
+		}, {
+			label: "Paste",
+			accelerator: "CmdOrCtrl+V",
+			selector: "paste:"
+		}, {
+			label: "Select All",
+			accelerator: "CmdOrCtrl+A",
+			selector: "selectAll:"
+		}]
+	}
+	
+	// Bundle submenus into a single template and build a menu object with it
+	let menuTemplate = [applicationSubMenu, editSubMenu]
+	let menuObject = Menu.buildFromTemplate(menuTemplate)
+	
+	// Assign it to the application
+	Menu.setApplicationMenu(menuObject)
+}
+
 function getPlatformIcon(filename){
     const opSys = process.platform
     if (opSys === 'darwin') {
@@ -137,6 +197,7 @@ function getPlatformIcon(filename){
 }
 
 app.on('ready', createWindow)
+app.on('ready', createMenu)
 
 app.on('window-all-closed', () => {
     // On macOS it is common for applications and their menu bar

--- a/index.js
+++ b/index.js
@@ -125,62 +125,67 @@ function createWindow() {
 }
 
 function createMenu() {
-	
-	// Extend default included application menu to continue support for quit keyboard shortcut
-	let applicationSubMenu = {
-		label: "Application",
-		submenu: [{
-			label: "About Application",
-			selector: "orderFrontStandardAboutPanel:"
-		}, {
-			type: "separator"
-		}, {
-			label: "Quit",
-			accelerator: "Command+Q",
-			click: () => {
-				app.quit()
-			}
-		}]
-	}
-	
-	// New edit menu adds support for text-editing keyboard shortcuts
-	let editSubMenu = {
-		label: "Edit",
-		submenu: [{
-			label: "Undo",
-			accelerator: "CmdOrCtrl+Z",
-			selector: "undo:"
-		}, {
-			label: "Redo",
-			accelerator: "Shift+CmdOrCtrl+Z",
-			selector: "redo:"
-		}, {
-			type: "separator"
-		}, {
-			label: "Cut",
-			accelerator: "CmdOrCtrl+X",
-			selector: "cut:"
-		}, {
-			label: "Copy",
-			accelerator: "CmdOrCtrl+C",
-			selector: "copy:"
-		}, {
-			label: "Paste",
-			accelerator: "CmdOrCtrl+V",
-			selector: "paste:"
-		}, {
-			label: "Select All",
-			accelerator: "CmdOrCtrl+A",
-			selector: "selectAll:"
-		}]
-	}
-	
-	// Bundle submenus into a single template and build a menu object with it
-	let menuTemplate = [applicationSubMenu, editSubMenu]
-	let menuObject = Menu.buildFromTemplate(menuTemplate)
-	
-	// Assign it to the application
-	Menu.setApplicationMenu(menuObject)
+    
+    if(process.platform === 'darwin') {
+
+        // Extend default included application menu to continue support for quit keyboard shortcut
+        let applicationSubMenu = {
+            label: 'Application',
+            submenu: [{
+                label: 'About Application',
+                selector: 'orderFrontStandardAboutPanel:'
+            }, {
+                type: 'separator'
+            }, {
+                label: 'Quit',
+                accelerator: 'Command+Q',
+                click: () => {
+                    app.quit()
+                }
+            }]
+        }
+
+        // New edit menu adds support for text-editing keyboard shortcuts
+        let editSubMenu = {
+            label: 'Edit',
+            submenu: [{
+                label: 'Undo',
+                accelerator: 'CmdOrCtrl+Z',
+                selector: 'undo:'
+            }, {
+                label: 'Redo',
+                accelerator: 'Shift+CmdOrCtrl+Z',
+                selector: 'redo:'
+            }, {
+                type: 'separator'
+            }, {
+                label: 'Cut',
+                accelerator: 'CmdOrCtrl+X',
+                selector: 'cut:'
+            }, {
+                label: 'Copy',
+                accelerator: 'CmdOrCtrl+C',
+                selector: 'copy:'
+            }, {
+                label: 'Paste',
+                accelerator: 'CmdOrCtrl+V',
+                selector: 'paste:'
+            }, {
+                label: 'Select All',
+                accelerator: 'CmdOrCtrl+A',
+                selector: 'selectAll:'
+            }]
+        }
+
+        // Bundle submenus into a single template and build a menu object with it
+        let menuTemplate = [applicationSubMenu, editSubMenu]
+        let menuObject = Menu.buildFromTemplate(menuTemplate)
+
+        // Assign it to the application
+        Menu.setApplicationMenu(menuObject)
+
+    }
+
 }
 
 function getPlatformIcon(filename){


### PR DESCRIPTION
Since it is no longer included by default, support for copy+paste across platforms requires the creation of an application menu that declares keyboard shortcuts, much like native macOS applications. Hope this helps!